### PR TITLE
Add CLAUDE.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ tests/
 
 # Claude Code
 .claude/
+CLAUDE.md
 
 # Build artifacts
 dist/


### PR DESCRIPTION
## Summary
- Add CLAUDE.md to .gitignore to keep Claude Code instructions local

## Test plan
- [x] CLAUDE.md is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)